### PR TITLE
Created PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,11 @@
-### Problem - ![](https://github.trello.services/images/mini-trello-icon.png) [Trello Card](YOUR_LINK_HERE)
+## Problem - ![](https://github.trello.services/images/mini-trello-icon.png) [Trello Card](YOUR_LINK_HERE)
 
 <!-- the problem, issue, or feature needing to be resolved -->
 
-### Solution
+## Solution
 
 <!-- the solution -->
 
-### Additional Notes
+## Additional Notes
 
 <!-- anything else that may be helpful such as any additional bug fixes, comments, or links to related documentation -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+### Problem - ![](https://github.trello.services/images/mini-trello-icon.png) [Trello Card](YOUR_LINK_HERE)
+
+<!-- the problem, issue, or feature needing to be resolved -->
+
+### Solution
+
+<!-- the solution -->
+
+### Additional Notes
+
+<!-- anything else that may be helpful such as any additional bug fixes, comments, or links to related documentation -->


### PR DESCRIPTION
## Problem - ![](https://github.trello.services/images/mini-trello-icon.png) [Trello Card](https://trello.com/c/uRxb3vtL/28-create-pr-template)

<!-- the problem, issue, or feature needing to be resolved -->
Our PRs on Github should be improved to look consistent and follow the same format.

## Solution

<!-- the solution -->
I created a Github PR template. Once this is merged, it should be reflected in future PRs and should be autopopulated when a new PR is created.

This PR is an example of the new template format. Take a good look :)

## Additional Notes

<!-- anything else that may be helpful such as any additional bug fixes, comments, or links to related documentation -->
After this PR is merged, we might need to merge `develop` into `master` for Github to use the template - I can't exactly remember if it uses branch-specific PR templates.